### PR TITLE
ReloadableJava8ParserVisitor handles constuctors having unknow types

### DIFF
--- a/src/main/java/org/openrewrite/java/ReloadableJava8ParserVisitor.java
+++ b/src/main/java/org/openrewrite/java/ReloadableJava8ParserVisitor.java
@@ -968,7 +968,7 @@ public class ReloadableJava8ParserVisitor extends TreePathScanner<J, Space> {
         }
 
         JCNewClass jcNewClass = (JCNewClass) node;
-        JavaType.Method constructorType = methodType(jcNewClass.constructorType, jcNewClass.constructor, "<constructor>");
+        JavaType.Method constructorType = type((jcNewClass.constructor).owner) != null ? methodType(jcNewClass.constructorType, jcNewClass.constructor, "<constructor>") : null;
 
         return new J.NewClass(randomId(), fmt, Markers.EMPTY, encl, whitespaceBeforeNew,
                 clazz, args, body, constructorType,
@@ -1519,7 +1519,6 @@ public class ReloadableJava8ParserVisitor extends TreePathScanner<J, Space> {
         // if the symbol is not a method symbol, there is a parser error in play
         Symbol.MethodSymbol methodSymbol = symbol instanceof Symbol.MethodSymbol ? (Symbol.MethodSymbol) symbol : null;
 
-        JavaType.Method type = null;
         if (methodSymbol != null && selectType != null) {
             Function<com.sun.tools.javac.code.Type, JavaType.Method.Signature> signature = t -> {
                 if (t instanceof MethodType) {


### PR DESCRIPTION
JCNewClass elements having missing types/symbols are assigned a new MethodSymbol constructor with an unknown Type. In that case, the J.NewClass should be constructed with a null constructorType.

Not handling this case resulted in a bug where the JavaTemplate parser could not extract a J.CompilationUnit from the generated source.